### PR TITLE
[BE] feat: create validGlobalPipe 

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -15,9 +15,12 @@ import { AuthResponseDto } from './dto/auth.response.dto';
 import { AuthService } from './auth.service';
 import { Response } from 'express';
 import { JwtAuthGuard } from './jwt-auth.guard';
+import { ValidateGlobalPipe } from '../validate-global.pipe';
+import { authError } from './auth.error';
 
 @ApiTags('Auth API')
 @Controller('auth')
+@UsePipes(new ValidateGlobalPipe(authError))
 export class AuthController {
   constructor(private authService: AuthService) {}
 

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -1,4 +1,13 @@
-import { Body, Controller, Delete, Get, Post, Req, Res, UseGuards } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Delete,
+  Post,
+  Req,
+  Res,
+  UseGuards,
+  UsePipes,
+} from '@nestjs/common';
 import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { SignInRequestDto } from './dto/signin-request.dto';
 import { SignUpRequestDto } from './dto/signup-request.dto';

--- a/src/auth/auth.error.ts
+++ b/src/auth/auth.error.ts
@@ -1,0 +1,5 @@
+export const authError = {
+  name: { code: 'AUTH_1', message: '이름 형식이 맞지 않습니다.' },
+  email: { code: 'AUTH_6', message: '이메일 형식이 맞지 않습니다.' },
+  password: { code: 'AUTH_7', message: '비밀번호 형식이 맞지 않습니다.' },
+};

--- a/src/auth/auth.exceptions.ts
+++ b/src/auth/auth.exceptions.ts
@@ -1,0 +1,15 @@
+import { HttpException, HttpStatus } from '@nestjs/common';
+
+export class validDataException extends HttpException {
+  constructor(message: string, code: string) {
+    super(
+      {
+        success: false,
+        status: HttpStatus.BAD_REQUEST,
+        code,
+        message,
+      },
+      HttpStatus.BAD_REQUEST,
+    );
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,13 +1,10 @@
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
-import { ValidationPipe } from '@nestjs/common';
 import * as cookieParser from 'cookie-parser';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
-  // validation dto
-  app.useGlobalPipes(new ValidationPipe());
   // use cookie-parser middleware as global
   app.use(cookieParser());
 

--- a/src/validate-global.pipe.ts
+++ b/src/validate-global.pipe.ts
@@ -1,0 +1,36 @@
+import {
+  ArgumentMetadata,
+  Injectable,
+  PipeTransform,
+  ValidationPipe,
+} from '@nestjs/common';
+import { ValidationError } from 'class-validator';
+import { validDataException } from './auth/auth.exceptions';
+
+/*
+ * catch class-validator exception
+ * Define a custom error type ex)authError
+ * useage : UsePipe(ValidateGlobalPipe(authError))
+ */
+@Injectable()
+export class ValidateGlobalPipe implements PipeTransform {
+  private errorType;
+  constructor(errorType) {
+    this.errorType = errorType;
+  }
+  async transform(value: any, metadata: ArgumentMetadata) {
+    console.log(value);
+
+    const validPipe = new ValidationPipe({
+      disableErrorMessages: true,
+      exceptionFactory: (error: ValidationError[]) => {
+        const properties = error.map((error) => error.property);
+        const { code, message } = this.errorType[properties[0]];
+        throw new validDataException(message, code);
+        console.log(code);
+      },
+    });
+    const val = await validPipe.transform(value, metadata);
+    return val;
+  }
+}

--- a/src/validate-global.pipe.ts
+++ b/src/validate-global.pipe.ts
@@ -7,7 +7,7 @@ import {
 import { ValidationError } from 'class-validator';
 import { validDataException } from './auth/auth.exceptions';
 
-/*
+/**
  * catch class-validator exception
  * Define a custom error type ex)authError
  * useage : UsePipe(ValidateGlobalPipe(authError))
@@ -30,7 +30,7 @@ export class ValidateGlobalPipe implements PipeTransform {
         console.log(code);
       },
     });
-    const val = await validPipe.transform(value, metadata);
-    return val;
+    const requestValue = await validPipe.transform(value, metadata);
+    return requestValue;
   }
 }


### PR DESCRIPTION
각 도메인에서 각 dto에 맞게 사용할 수 있는 ValidateGlobalPipe라는 customPipe를 생성했습니다.

각 도메인에서 error message객체를 만들어서 custompipe 호출 시 사용하면됩니다.
ex) UsePipe(ValidGlobalPipe(authError)) 

- closes #13 