### PR TITLE
[BE] fix: findRoomSocket에서 watingSockets를 탐색할 때, async 제거

### DIFF
--- a/src/conversation-events/conversation-events.gateway.ts
+++ b/src/conversation-events/conversation-events.gateway.ts
@@ -98,6 +98,9 @@ export class ConversationEventsGateway
     if (client.status == undefined || client.status == SocketStatus.REFLASING) {
       return;
     }
+    this.logger.log(
+      `${client.user.name}이 다음 상태에서 종료: ${client.status}`,
+    );
     // TODO: type에 따라서 방의 상태도 바꾸기
     const room: Room = client.room;
     const user: User = client.user;

--- a/src/rooms/rooms.service.ts
+++ b/src/rooms/rooms.service.ts
@@ -42,7 +42,7 @@ export class RoomsService {
       return room.participantSocket;
     }
     const sameWaitingUser = room.watingSockets.find(
-      async (socket) => socket.user.pk == user.pk,
+      (socket) => socket.user.pk == user.pk,
     );
     return sameWaitingUser;
   }


### PR DESCRIPTION
## 주요 변경사항
findRoomSocket에서 watingSockets를 탐색할 때, async 제거
바꾼 이유: find할 때 return 값이 promise면 true로 인식해서 find가 의미 없어 짐

## 리뷰어에게...

## 관련 이슈

closes
