### PR TITLE
[BE] Feat: 참여한 회의와 회의록 정보 API를 구현한다.

### DIFF
--- a/src/conversation-datas/conversation-datas.module.ts
+++ b/src/conversation-datas/conversation-datas.module.ts
@@ -14,5 +14,6 @@ import { ConversationDatas } from './entities/conversations-data.entity';
   ],
   providers: [ConversationDatasService],
   controllers: [ConversationDatasController],
+  exports: [ConversationDatasService],
 })
 export class ConversationDatasModule {}

--- a/src/conversation-datas/conversation-datas.service.ts
+++ b/src/conversation-datas/conversation-datas.service.ts
@@ -14,7 +14,7 @@ export class ConversationDatasService {
   constructor(
     private configService: ConfigService,
     @InjectRepository(ConversationDatas)
-    private conversationDatasReoisitory: Repository<ConversationDatas>,
+    private conversationDatasRepository: Repository<ConversationDatas>,
   ) {
     this.s3Client = new S3Client({
       region: this.configService.get('AWS_REGION'),

--- a/src/conversation-datas/conversation-datas.service.ts
+++ b/src/conversation-datas/conversation-datas.service.ts
@@ -79,4 +79,15 @@ export class ConversationDatasService {
       return false;
     }
   }
+
+  async getConversationDatas(pk: number) {
+    try {
+      const conversationDatas = this.conversationDatasRepository.findOneBy({
+        pk,
+      });
+      return conversationDatas;
+    } catch (error) {
+      return false;
+    }
+  }
 }

--- a/src/conversation-datas/conversation-datas.service.ts
+++ b/src/conversation-datas/conversation-datas.service.ts
@@ -71,8 +71,8 @@ export class ConversationDatasService {
   async createConversationDatas(saveData: SaveDatasDto) {
     try {
       const conversationDatas =
-        await this.conversationDatasReoisitory.create(saveData);
-      await this.conversationDatasReoisitory.save(conversationDatas);
+        await this.conversationDatasRepository.create(saveData);
+      await this.conversationDatasRepository.save(conversationDatas);
       return true;
     } catch (error) {
       console.log(error);

--- a/src/conversation-datas/entities/conversations-data.entity.ts
+++ b/src/conversation-datas/entities/conversations-data.entity.ts
@@ -1,7 +1,7 @@
 import { Conversation } from 'src/conversations/entities/conversation.entity';
 import { Column, Entity, OneToOne, PrimaryGeneratedColumn } from 'typeorm';
 
-@Entity()
+@Entity('ConversationDatas')
 export class ConversationDatas {
   @PrimaryGeneratedColumn()
   pk: number;

--- a/src/conversations/conversations.controller.ts
+++ b/src/conversations/conversations.controller.ts
@@ -5,24 +5,46 @@ import {
   Body,
   Patch,
   Param,
+  Request,
   Delete,
+  UseGuards,
 } from '@nestjs/common';
 import { ConversationsService } from './conversations.service';
 import { UpdateConversationDto } from './dto/update-conversation.dto';
-import { ConversationDto } from './dto/conversation.dto';
+import { JwtPayloadDto } from 'src/auth/dto/jwt-payload';
+import { UsersService } from 'src/users/users.service';
+import { JwtAuthGuard } from 'src/auth/jwt-auth.guard';
+import { ApiOperation, ApiResponse } from '@nestjs/swagger';
+import { ConversationResponseDto } from './dto/conversation-response.dto';
 
 @Controller('conversations')
 export class ConversationsController {
-  constructor(private readonly conversationsService: ConversationsService) {}
-       
-  @Post()
-  create(@Body() createConversationDto: ConversationDto) {
-    return this.conversationsService.create(createConversationDto);
-  }
+  constructor(
+    private readonly conversationsService: ConversationsService,
+    private readonly userService: UsersService,
+  ) {}
 
+  @ApiOperation({
+    summary: '회의록 요청',
+    description: '내가 참여한 회의록을 요청한다..',
+  })
+  @ApiResponse({
+    status: 200,
+    description: '회의록 요청 성공',
+    type: ConversationResponseDto,
+  })
+  @UseGuards(JwtAuthGuard)
   @Get()
-  findAll() {
-    return this.conversationsService.findAll();
+  async findAll(@Request() req: Request & { user: JwtPayloadDto }) {
+    const { email, name }: JwtPayloadDto = req.user;
+    const user = await this.userService.findOne(email);
+    console.log('this is find conversations');
+
+    return {
+      data: {
+        conversations: await this.conversationsService.findAll(user.pk),
+      },
+    };
   }
 
   @Get(':id')

--- a/src/conversations/conversations.controller.ts
+++ b/src/conversations/conversations.controller.ts
@@ -47,9 +47,17 @@ export class ConversationsController {
     };
   }
 
-  @Get(':id')
-  findOne(@Param('id') id: string) {
-    return this.conversationsService.findOne(+id);
+  @UseGuards(JwtAuthGuard)
+  @ApiOperation({
+    summary: '회의록 데이터 요청',
+    description: '회의록에 대한 회의 내용을 요청한다.',
+  })
+  @Get(':dataPk')
+  getConversationDatas(
+    @Request() req: Request & { user: JwtPayloadDto },
+    @Param('dataPk') dataPk: number,
+  ) {
+    return this.conversationsService.getConversationDatas(req.user, dataPk);
   }
 
   @Patch(':id')

--- a/src/conversations/conversations.controller.ts
+++ b/src/conversations/conversations.controller.ts
@@ -59,17 +59,20 @@ export class ConversationsController {
   ) {
     return this.conversationsService.getConversationDatas(req.user, dataPk);
   }
-
-  @Patch(':id')
+  @ApiOperation({
+    summary: '회의록 데이터 요청',
+    description: '회의록에 대한 회의 내용을 요청한다.',
+  })
+  @Patch(':dataPk')
   update(
-    @Param('id') id: string,
+    @Param('dataPk') dataPk: number,
     @Body() updateConversationDto: UpdateConversationDto,
   ) {
-    return this.conversationsService.update(+id, updateConversationDto);
+    return this.conversationsService.update(dataPk, updateConversationDto);
   }
 
-  @Delete(':id')
-  remove(@Param('id') id: string) {
-    return this.conversationsService.remove(+id);
+  @Delete(':dataPk')
+  remove(@Param('dataPk') dataPk: number) {
+    return this.conversationsService.remove(dataPk);
   }
 }

--- a/src/conversations/conversations.module.ts
+++ b/src/conversations/conversations.module.ts
@@ -1,8 +1,18 @@
 import { Module } from '@nestjs/common';
 import { ConversationsService } from './conversations.service';
 import { ConversationsController } from './conversations.controller';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Conversation } from './entities/conversation.entity';
+import { UsersModule } from 'src/users/users.module';
+import { ConversationDatas } from 'src/conversation-datas/entities/conversations-data.entity';
+import { ConversationDatasModule } from 'src/conversation-datas/conversation-datas.module';
 
 @Module({
+  imports: [
+    TypeOrmModule.forFeature([Conversation]),
+    UsersModule,
+    ConversationDatasModule
+  ],
   controllers: [ConversationsController],
   providers: [ConversationsService],
 })

--- a/src/conversations/conversations.service.ts
+++ b/src/conversations/conversations.service.ts
@@ -1,6 +1,12 @@
-import { Injectable } from '@nestjs/common';
+import { HttpException, HttpStatus, Injectable } from '@nestjs/common';
 import { UpdateConversationDto } from './dto/update-conversation.dto';
 import { ConversationDto } from './dto/conversation.dto';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Conversation } from './entities/conversation.entity';
+import { Repository } from 'typeorm';
+import { ConversationDatas } from 'src/conversation-datas/entities/conversations-data.entity';
+import { ConversationDatasService } from 'src/conversation-datas/conversation-datas.service';
+import { UsersService } from 'src/users/users.service';
 
 @Injectable()
 export class ConversationsService {
@@ -40,8 +46,30 @@ export class ConversationsService {
     return conversations;
   }
 
-  findOne(id: number) {
-    return `This action returns a #${id} conversation`;
+  async getConversationDatas(user, dataPk: number) {
+    const conversation = await this.conversationRepository.findOneBy({
+      dataPk,
+    });
+    const conversationDatas =
+      this.conversationDatasService.getConversationDatas(dataPk);
+    // TODO: Custom Exception으로 처리 (에러 코드와 함께 처리)
+    if (!conversation || !conversationDatas) {
+      throw new HttpException(
+        '회의가 종료되지 않았습니다.',
+        HttpStatus.BAD_REQUEST,
+      );
+    }
+
+    const userPk = (await this.usersServie.findOne(user.email)).pk;
+
+    if (conversation.creatorPk != userPk) {
+      throw new HttpException(
+        '참여하지 않은 회의입니다.',
+        HttpStatus.BAD_REQUEST,
+      );
+    }
+    console.log(conversation);
+    return conversationDatas;
   }
 
   update(id: number, updateConversationDto: UpdateConversationDto) {

--- a/src/conversations/conversations.service.ts
+++ b/src/conversations/conversations.service.ts
@@ -4,12 +4,40 @@ import { ConversationDto } from './dto/conversation.dto';
 
 @Injectable()
 export class ConversationsService {
-  create(createConversationDto: ConversationDto) {
-    return 'This action adds a new conversation';
+  constructor(
+    @InjectRepository(Conversation)
+    private conversationRepository: Repository<Conversation>,
+    private conversationDatasService: ConversationDatasService,
+    private usersServie: UsersService,
+  ) {}
+  async createConversation(conversationDto: ConversationDto) {
+    // TODO : Exception 처리 하기
+    try {
+      const conversation = this.conversationRepository.create(conversationDto);
+      await this.conversationRepository.save(conversation);
+      return true;
+    } catch (error) {
+      return false;
+    }
   }
 
-  findAll() {
-    return `This action returns all conversations`;
+  async findAll(userPk: number) {
+    const conversations = await this.conversationRepository
+      .createQueryBuilder('conversation')
+      .leftJoinAndSelect('conversation.creator', 'creator')
+      .leftJoinAndSelect('conversation.participant', 'participant')
+      .select([
+        'conversation',
+        'creator.email',
+        'creator.name',
+        'participant.name',
+        'participant.email',
+      ])
+      .where('conversation.creatorPk =:userPk', { userPk })
+      .orWhere('conversation.participantPk =:userPk', { userPk })
+      .orderBy('conversation.startedAt', 'DESC')
+      .getMany();
+    return conversations;
   }
 
   findOne(id: number) {

--- a/src/conversations/dto/conversation-response.dto.ts
+++ b/src/conversations/dto/conversation-response.dto.ts
@@ -1,6 +1,6 @@
-import { ApiProperty } from '@nestjs/swagger';
+import { ApiExtraModels, ApiProperty } from '@nestjs/swagger';
 import { ConversationDto } from './conversation.dto';
-
+@ApiExtraModels(ConversationDto)
 export class ConversationResponseDto {
   @ApiProperty({
     example: 'conversations:[{...conversation}]',

--- a/src/conversations/dto/conversation.dto.ts
+++ b/src/conversations/dto/conversation.dto.ts
@@ -1,14 +1,53 @@
-import { ApiProperty } from '@nestjs/swagger';
-import { IsNotEmpty } from 'class-validator';
+import { ApiExtraModels, ApiProperty } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import { IsEmail, IsNotEmpty, IsString } from 'class-validator';
+
+class UserDto {
+  @ApiProperty({
+    example: '지창근',
+    description: 'creators email/회의 참석자 이름',
+  })
+  @IsString()
+  name: string;
+
+  @ApiProperty({
+    example: 'pig19980@github.com',
+    description: 'creators email/회의 참석자 이름',
+  })
+  @IsEmail()
+  email: string;
+}
 
 // TODO: 하나만 조회하거나 하나의 conversation에 대해서 확인하는 로직없다면 ConversationListResponseDto에 합친다.
+@ApiExtraModels(UserDto)
 export class ConversationDto {
   @ApiProperty({
-    example: '4069e5fa-7e24-4be0-958b-999aa8922e13',
-    description: 'Conversation UUID / 회의 UUID',
+    example: '1',
+    description: '회의록 pk',
   })
   @IsNotEmpty()
-  uuid: string;
+  pk: number;
+
+  @ApiProperty({
+    example: '1',
+    description: 'creator pk',
+  })
+  @IsNotEmpty()
+  creatorPk: number;
+
+  @ApiProperty({
+    example: '1',
+    description: 'participant pk',
+  })
+  @IsNotEmpty()
+  participantPk: number;
+
+  @ApiProperty({
+    example: '1',
+    description: 'conversationDatas Pk',
+  })
+  @IsNotEmpty()
+  dataPk: number;
 
   @ApiProperty({
     example: '10월 17일 로그인 구현 PR',
@@ -31,46 +70,9 @@ export class ConversationDto {
   @IsNotEmpty()
   finishedAt: Date;
 
-  @ApiProperty({
-    example: '4069e5fa-7e24-4be0-958b-999aa8922e13',
-    description: '회의록 공유 Url',
-  })
   @IsNotEmpty()
-  shareUrl: string;
+  creator: UserDto;
 
-  @ApiProperty({
-    example: 'true',
-    description: '회의 공유 가능 여부',
-  })
   @IsNotEmpty()
-  canShared: boolean;
-
-  @ApiProperty({
-    example: 'whguddnr9@github.com',
-    description: 'creators email/회의 개설자 이메일',
-  })
-  @IsNotEmpty()
-  creatorEmail: string;
-
-  @ApiProperty({
-    example: 'whguddnr9@github.com',
-    description: 'creators email/회의 개설자 이름',
-  })
-  @IsNotEmpty()
-  creatorName: string;
-
-  @ApiProperty({
-    example: 'pig19980@github.com',
-    description: 'creators email/회의 참석자 이메일',
-  })
-  @IsNotEmpty()
-  @IsNotEmpty()
-  participantEmail: string;
-
-  @ApiProperty({
-    example: '지창근',
-    description: 'creators email/회의 참석자 이름',
-  })
-  @IsNotEmpty()
-  partipantName: string;
+  participant: UserDto;
 }

--- a/src/conversations/entities/conversation.entity.ts
+++ b/src/conversations/entities/conversation.entity.ts
@@ -3,12 +3,13 @@ import { User } from 'src/users/entities/user.entity';
 import {
   Column,
   Entity,
+  JoinColumn,
   ManyToOne,
   OneToOne,
   PrimaryGeneratedColumn,
 } from 'typeorm';
 
-@Entity()
+@Entity('Conversation')
 export class Conversation {
   @PrimaryGeneratedColumn()
   pk: number;
@@ -38,7 +39,9 @@ export class Conversation {
     (Type) => ConversationDatas,
     (conversationDatas) => conversationDatas.conversation,
   )
-  conversationDatas: ConversationDatas[];
+  @JoinColumn({ name: 'dataPk' })
+  conversationDatas: ConversationDatas;
+
   @ManyToOne((type) => User, (user) => user.createConversations)
   creator: User;
 

--- a/src/users/entities/user.entity.ts
+++ b/src/users/entities/user.entity.ts
@@ -8,7 +8,7 @@ import {
   Unique,
 } from 'typeorm';
 
-@Entity()
+@Entity('User')
 @Unique(['email'])
 export class User {
   @PrimaryGeneratedColumn()


### PR DESCRIPTION
## 주요 변경사항
###기존 conversation dto 수정
- response로 주는 곳 conversation[] 배열로 전송
- conversationDto에 응답값에 UserDto를 사용하도록 수정

### Conversation API 구현
- 참여한 회의를 보여주는 API 구현
- 참여한 회의의 회의록을 보여주는 API 구현
- Conversation에 User, Conversation-Datas 의존성 추가
### Entyies 이름 명세화

## 리뷰어에게...

## 관련 이슈

closes #130 
