### PR TITLE
fix: 공유 여부 확인하는 조건을 undefined로 처리한다.

### DIFF
--- a/src/conversation-datas/conversation-datas.service.ts
+++ b/src/conversation-datas/conversation-datas.service.ts
@@ -164,7 +164,7 @@ export class ConversationDatasService {
         const updateData = updateConversationDataDto[type];
         if (!updateData) continue;
 
-        if (updateData.isShared) {
+        if (updateData.isShared !== undefined) {
           conversationData[FileConfig.SHARED_COLUMN_MAP[type]] =
             updateData.isShared;
         }


### PR DESCRIPTION
## 주요 변경사항
공유 여부를 true에서 false로 변경했을 때 처리안되는 문제발생
- 조건문을 값이 있는지 없는지로 처리를 했는데 false 로 처리 시 조건문도 false가 되면서 처리가 안되는 오류 발생

조건문을 undefined여부로 처리해서 해결


## 리뷰어에게...

## 관련 이슈

closes
