### PR TITLE
[BE]: refactor: creator가 아닐 때 ValidateUserIsCreatorPipe를 지나면, ConversationException을 던지도록 수정

### DIFF
--- a/src/conversation-events/conversation-events.filter.ts
+++ b/src/conversation-events/conversation-events.filter.ts
@@ -1,6 +1,10 @@
 import { ArgumentsHost, Catch, ExceptionFilter, Logger } from '@nestjs/common';
 import { WsException } from '@nestjs/websockets';
 import { Socket } from 'socket.io';
+import {
+  disconenctRoomSocket,
+  RoomSocket,
+} from './interfaces/room-socket.interface';
 
 export interface ConversationError {
   code: string;
@@ -24,7 +28,7 @@ export class ConversationEventsFilter<T> implements ExceptionFilter {
   catch(exception: Error, host: ArgumentsHost) {
     const ctx = host.switchToWs();
     const event = ctx.getPattern();
-    const client = ctx.getClient<Socket>();
+    const client = ctx.getClient<RoomSocket>();
     if (exception instanceof ConversationException) {
       client.emit('exception', {
         success: false,
@@ -33,7 +37,7 @@ export class ConversationEventsFilter<T> implements ExceptionFilter {
         message: exception.message,
       });
       if (exception.withTerminate) {
-        client.disconnect(true);
+        disconenctRoomSocket(client);
       }
       return;
     }

--- a/src/conversation-events/interfaces/room-socket.interface.ts
+++ b/src/conversation-events/interfaces/room-socket.interface.ts
@@ -48,6 +48,9 @@ export function disconenctRoomSocket(socket: RoomSocket) {
   if (!socket) {
     return;
   }
+  if (!socket.status) {
+    socket.disconnect(true);
+  }
   switch (socket.status) {
     case SocketStatus.WAITER:
       socket.emit('invite-rejected', {

--- a/src/conversation-events/pipes/validate-user-is-creator.pipe.ts
+++ b/src/conversation-events/pipes/validate-user-is-creator.pipe.ts
@@ -1,13 +1,17 @@
 import { ArgumentMetadata, Injectable, PipeTransform } from '@nestjs/common';
 import { RoomSocket, SocketStatus } from '../interfaces/room-socket.interface';
-import { WsException } from '@nestjs/websockets';
+import { ConversationException } from '../conversation-events.filter';
 
 @Injectable()
 export class ValidateUserIsCreatorPipe implements PipeTransform {
   transform(value: RoomSocket, metadata: ArgumentMetadata) {
     if (value.constructor && value.constructor.name == 'Socket') {
       if (value.status != SocketStatus.CREATOR) {
-        throw new WsException(`방장이 아닙니다.: ${value.status}`);
+        throw new ConversationException(
+          'PERMISSION_1',
+          '권한이 없습니다.',
+          true,
+        );
       }
     }
     return value;


### PR DESCRIPTION
creator가 아닐 때 ValidateUserIsCreatorPipe를 지나면, ConversationException을 던지도록 수정

## 주요 변경사항

## 리뷰어에게...

## 관련 이슈

closes
